### PR TITLE
Slightly more correct reading of file headers for compressed resource…

### DIFF
--- a/LibSanBag.Tests/TestOodleLz.cs
+++ b/LibSanBag.Tests/TestOodleLz.cs
@@ -65,17 +65,6 @@ namespace LibSanBag.Tests
         }
 
         [Test]
-        public void TestUnknownCompressionHeader()
-        {
-            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Samples", "OodleLz", "UnknownCompressionHeader.bin");
-
-            Assert.Throws<NotImplementedException>(() =>
-            {
-                Unpacker.DecompressResource(path);
-            });
-        }
-
-        [Test]
         public void TestExtractWhileUnavailable()
         {
             var fileProvider = new MockFileProvider();

--- a/LibSanBag/ResourceUtils/LibOodle6.cs
+++ b/LibSanBag/ResourceUtils/LibOodle6.cs
@@ -7,7 +7,7 @@ namespace LibSanBag.ResourceUtils
     internal class LibOodle6 : LibOodleBase
     {
         [DllImport("oo2core_6_win64.dll")]
-        private static extern ulong OodleLZ_Compress(int codec, byte[] buffer, ulong bufferLength, IntPtr output, int level, IntPtr a, IntPtr b, IntPtr c);
+        private static extern ulong OodleLZ_Compress(int codec, byte[] buffer, ulong bufferLength, byte[] output, int level, IntPtr a, IntPtr b, IntPtr c, IntPtr d, IntPtr e);
 
         [DllImport("oo2core_6_win64.dll")]
         private static extern ulong OodleLZ_Decompress(byte[] compressed, ulong compressedSize, byte[] decompressed, ulong decompressedSize, int a, int b, int c, IntPtr d, IntPtr e, IntPtr f, IntPtr g, IntPtr h, IntPtr i, int j);
@@ -17,8 +17,8 @@ namespace LibSanBag.ResourceUtils
             return fileProvider.FileExists("oo2core_6_win64.dll");
         }
 
-        public override ulong Compress(int codec, byte[] buffer, ulong bufferLength, IntPtr output, int level, IntPtr a, IntPtr b, IntPtr c) 
-            => OodleLZ_Compress(codec, buffer, bufferLength, output, level, a, b, c);
+        public override ulong Compress(int codec, byte[] buffer, ulong bufferLength, byte[] output, int level, IntPtr a, IntPtr b, IntPtr c, IntPtr d, IntPtr e) 
+            => OodleLZ_Compress(codec, buffer, bufferLength, output, level, a, b, c, d, e);
         public override ulong Decompress(byte[] compressed, ulong compressedSize, byte[] decompressed, ulong decompressedSize, int a, int b, int c, IntPtr d, IntPtr e, IntPtr f, IntPtr g, IntPtr h, IntPtr i, int j) 
             => OodleLZ_Decompress(compressed, compressedSize, decompressed, decompressedSize, a, b, c, d, e, f, g, h, i, j);
     }

--- a/LibSanBag/ResourceUtils/LibOodle7.cs
+++ b/LibSanBag/ResourceUtils/LibOodle7.cs
@@ -7,7 +7,7 @@ namespace LibSanBag.ResourceUtils
     internal class LibOodle7 : LibOodleBase
     {
         [DllImport("oo2core_7_win64.dll")]
-        private static extern ulong OodleLZ_Compress(int codec, byte[] buffer, ulong bufferLength, IntPtr output, int level, IntPtr a, IntPtr b, IntPtr c);
+        private static extern ulong OodleLZ_Compress(int codec, byte[] buffer, ulong bufferLength, byte[] output, int level, IntPtr a, IntPtr b, IntPtr c, IntPtr d, IntPtr e);
 
         [DllImport("oo2core_7_win64.dll")]
         private static extern ulong OodleLZ_Decompress(byte[] compressed, ulong compressedSize, byte[] decompressed, ulong decompressedSize, int a, int b, int c, IntPtr d, IntPtr e, IntPtr f, IntPtr g, IntPtr h, IntPtr i, int j);
@@ -17,8 +17,8 @@ namespace LibSanBag.ResourceUtils
             return fileProvider.FileExists("oo2core_7_win64.dll");
         }
 
-        public override ulong Compress(int codec, byte[] buffer, ulong bufferLength, IntPtr output, int level, IntPtr a, IntPtr b, IntPtr c) 
-            => OodleLZ_Compress(codec, buffer, bufferLength, output, level, a, b, c);
+        public override ulong Compress(int codec, byte[] buffer, ulong bufferLength, byte[] output, int level, IntPtr a, IntPtr b, IntPtr c, IntPtr d, IntPtr e) 
+            => OodleLZ_Compress(codec, buffer, bufferLength, output, level, a, b, c, d, e);
         public override ulong Decompress(byte[] compressed, ulong compressedSize, byte[] decompressed, ulong decompressedSize, int a, int b, int c, IntPtr d, IntPtr e, IntPtr f, IntPtr g, IntPtr h, IntPtr i, int j) 
             => OodleLZ_Decompress(compressed, compressedSize, decompressed, decompressedSize, a, b, c, d, e, f, g, h, i, j);
     }

--- a/LibSanBag/ResourceUtils/LibOodleBase.cs
+++ b/LibSanBag/ResourceUtils/LibOodleBase.cs
@@ -5,7 +5,7 @@ namespace LibSanBag.ResourceUtils
 {
     public abstract class LibOodleBase
     {
-        public abstract ulong Compress(int codec, byte[] buffer, ulong bufferLength, IntPtr output, int level, IntPtr a, IntPtr b, IntPtr c) ;
+        public abstract ulong Compress(int codec, byte[] buffer, ulong bufferLength, byte[] output, int level, IntPtr a, IntPtr b, IntPtr c, IntPtr d, IntPtr e) ;
         public abstract ulong Decompress(byte[] compressed, ulong compressedSize, byte[] decompressed, ulong decompressedSize, int a, int b, int c, IntPtr d, IntPtr e, IntPtr f, IntPtr g, IntPtr h, IntPtr i, int j);
 
         public static LibOodleBase CreateLibOodle(IFileProvider fileProvider)
@@ -34,7 +34,7 @@ namespace LibSanBag.ResourceUtils
             var decompressedBuffer = new byte[decompressedSize];
 
             // TODO: This first call to compress was needed long ago for some reason, decompress would fail otherwise with oodle2
-            var x = Compress(0, null, 0, IntPtr.Zero, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            var x = Compress(0, null, 0, null, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
             var result = Decompress(
                 compressedData,
                 (ulong)compressedData.Length,


### PR DESCRIPTION
…s (for 0xF5, 0xF6, headers)